### PR TITLE
Fix: Minor typo in error message & improve button styling

### DIFF
--- a/articleRole.js
+++ b/articleRole.js
@@ -1,0 +1,34 @@
+"use strict";
+
+var _Object$defineProperty = require("@babel/runtime-corejs3/core-js-stable/object/define-property");
+
+_Object$defineProperty(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var articleRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-posinset': null,
+    'aria-setsize': null
+  },
+  relatedConcepts: [{
+    concept: {
+      name: 'article'
+    },
+    module: 'HTML'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'document']]
+};
+var _default = articleRole;
+exports.default = _default;


### PR DESCRIPTION
This commit addresses a couple of minor issues:

1. **Fixed a typo** in the error message displayed when a user attempts to submit an invalid form.  The word 'sucessful' was incorretly spelled.
2. **Improved the styling** of the 'Submit' button for better visual consistency across the application.  The padding was a litle off and has been adjusted.